### PR TITLE
Add AssignRequest to PreImage.IsAvailableFor

### DIFF
--- a/src/FakeXrmEasy.Plugins/PluginImages/PreImage.cs
+++ b/src/FakeXrmEasy.Plugins/PluginImages/PreImage.cs
@@ -33,7 +33,8 @@ namespace FakeXrmEasy.Plugins.PluginImages
         internal static bool IsAvailableFor(Type organizationRequestType)
         {
             return organizationRequestType == typeof(UpdateRequest)
-                   || organizationRequestType == typeof(DeleteRequest);
+                   || organizationRequestType == typeof(DeleteRequest)
+                   || organizationRequestType == typeof(AssignRequest);
         }
     }
 }


### PR DESCRIPTION
While Microsoft has announced that they are deprecating the AssignRequest, it is still in active use, even by MS themselves.

The Assign button inside the Ribbon, available on specific entities in model-driven apps, does not use the Update message - as would be preferred - but rather uses the Assign message.

The Assign message in turn does support PreImages for Plugin Registration. In order to properly reflect this I suggest adding it to the "IsAvailableFor" method in the PreImage class.

**What issue does this PR address?**

Currently, when using FakeXrmEasy to test AssignRequest based Plugins, which do in fact have PreImages registered on them, I receive the following error message: `FakeXrmEasy.Plugins.PluginSteps.InvalidRegistrationExceptions.PreImageNotAvailableException : The preimage with name 'PreImage' is not available for the message and stage specified.`

By adding the Assign message to the messages which can have a PreImage, this error would be mitigated.

**Important: Any code or remarks in your Pull Request are under the following terms:**

You acknowledge and agree that by submitting a request or making any code, comment, remark, feedback, enhancements, or modifications proposed or suggested by You in your pull request, You are deemed to accept the terms of our [Contributor License Agreement (CLA)](https://github.com/DynamicsValue/licence-agreements/blob/main/FakeXrmEasy/CLA.md) and that the CLA document is fully enforceable and effective for You. 

